### PR TITLE
jQuery.height() API does not return the height

### DIFF
--- a/example.html
+++ b/example.html
@@ -14,7 +14,7 @@ $(function() {
 	// Bind an element with a scroll zone
 	$("#toFixed").scrollPoint({
 		up   : $('#col').offset().top - pitch,
-		down : $('#col').offset().top - pitch + $('#col').height() - $('#toFixed').height(),
+		down : $('#col').offset().top - pitch + $('#col').outerHeight() - $('#toFixed').outerHeight(),
 	})
 	
 	// Event when the scroll offset enter the scroll zone
@@ -30,7 +30,7 @@ $(function() {
 		var TOP = 0
 		
 		if ($(window).scrollTop() > $('#col').offset().top) { 
-		    TOP = $('#col').height() - $('#toFixed').height();
+		    TOP = $('#col').outerHeight() - $('#toFixed').outerHeight();
 		}
 	
 		$(this).css({
@@ -80,7 +80,8 @@ body{
 
 #toFixed {
 	width:100px;
-	height: 100px;
+	height: 50px;
+	padding-top: 50px;
 	background: black;
 }
 

--- a/jQuery.scrollPoint.js
+++ b/jQuery.scrollPoint.js
@@ -44,7 +44,7 @@
             }
 
             if (!down && down !== 0) {
-                down = up + element.height();
+                down = up + element.outerHeight();
             }
 
             up   -= params.offsetUp;


### PR DESCRIPTION
Hi Jeremie !

I submit this pull request to you as a bugfix.
You used the [jQuery.height( ) API](http://api.jquery.com/height/), but I think you wanted to use the [jQuery.outerHeight( ) API](http://api.jquery.com/outerHeight/).
The difference is that your default down value seems not right for element with padding or borders.

I also updated the example file to always use outerHeight API, because I think it better represents what you had in mind.
By this way, your script doesn't depends anymore of padding or border properties.
In this spirit, I added padding to the '#toFixed" element.

Thanks for sharing this script.

See you,
Thomas.
