### PR TITLE
Trigger an event when passing from isDown to isUp directly

### DIFF
--- a/jQuery.scrollPoint.js
+++ b/jQuery.scrollPoint.js
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2014 Jeremie Patonnier
+    Copyright (c) 2012 - 2014 Jeremie Patonnier
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
     in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
Hi @JeremiePat!

I found a bug when a user scrolls from isDown to isUp directly, without passing to isIn.
For example, this case happens when the page is scrolled to the top with an empty anchor.

Cheers,
Thomas.
