### PR TITLE
Trigger an enter & a leave event when passing from isDown to isUp directly 

### DIFF
--- a/jQuery.scrollPoint.js
+++ b/jQuery.scrollPoint.js
@@ -72,6 +72,10 @@
                 relativePos.isIn   = !relativePos.isUp && !relativePos.isDown;
                 
                 if (oldRelativePos.isIn !== relativePos.isIn || oldRelativePos.isUp !== relativePos.isUp) {
+                    // If the scroll jumped directly between isUp and isDown
+                    if (oldRelativePos.isIn === relativePos.isIn) {
+                        triggerEvent("scrollPointEnter", relativePos);
+                    }
                     triggerEvent("scrollPoint" + (relativePos.isIn ? "Enter" : "Leave"), relativePos);
                 }
 


### PR DESCRIPTION
Hi @JeremiePat!

Like I said in the [previous PR](https://github.com/JeremiePat/jQuery-scrollPoint/pull/3#issuecomment-59897765), there is one more improvement.
You could not like this one, so I separated it from the previous one.

The problem come when we have a code that have a `isUp` (or `isDown`) state that are determined by `isIn` handler.
It happens when there is only a different behaviour between `isDown` & `isIn`, so `isUp` only inherit the `isIn` state.
In this case, when we scroll directly from `isDown` to `isUp`, we will not fired an `isIn` event and it could be source of bug or duplicate code.

Here is a code example, with the fixed header implementation:

```js
    $header = $('header');
    $header.scrollPoint({
        up: $header.offset().top,
    });
    $(document)
    .on('scrollPointEnter', 'header', function() {
        // Not reached if scrolling from `isDown` to `isUp` directly
        $header.removeClass('sticky');
    })
    .on('scrollPointLeave', 'header', function(event) {
        if ( event.isDown ) {
            $header.addClass('sticky');
        } else {
            // Reached if scrolling from `isDown` to `isUp` directly
            // So we have to duplicate `scrollPointEnter` handler here
            $header.removeClass('sticky');
        }
    }
```

A solution is to fire `scrollPointEnter` and a `scrollPointLeave` event when the scroll is jumped directly between `isDown` and `isUp`.

This is a tricky bug... and this is not a critical fix, but it could avoid some bugs.
I just hope I explained it right.

Cheers,
Thomas.